### PR TITLE
Hit 149 session notes

### DIFF
--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -36,7 +36,7 @@
         <!-- End of the set that can be customized -->
 
         <key>JVMRuntime</key>
-        <string>jdk-17.0.6+10</string>
+        <string>jdk-17.0.8+7</string>
 
         <key>JVMMainClassName</key>
         <string>OpenBCI_GUI</string>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
 String localGUIVersionString = "v6.0.0-beta.1";
-String localGUIVersionDate = "2024/10/28 15:43:59";
+String localGUIVersionDate = "2024/10/29 15:49:10";
 String guiLatestVersionGithubAPI = "https://api.github.com/repos/OpenBCI/OpenBCI_GUI/releases/latest";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiIsUpToDate;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
 String localGUIVersionString = "v6.0.0-beta.1";
-String localGUIVersionDate = "September 2023";
+String localGUIVersionDate = "2024/10/28 15:43:59";
 String guiLatestVersionGithubAPI = "https://api.github.com/repos/OpenBCI/OpenBCI_GUI/releases/latest";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiIsUpToDate;

--- a/OpenBCI_GUI/PopupMessage.pde
+++ b/OpenBCI_GUI/PopupMessage.pde
@@ -1,5 +1,7 @@
 import java.awt.Frame;
 import processing.awt.PSurfaceAWT;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 
 // Instantiate this class to show a popup message
 
@@ -17,6 +19,7 @@ class PopupMessage extends PApplet implements Runnable {
     private String headerMessage = "Error";
     private String buttonMessage = "OK";
     private String buttonLink = null;
+    private Boolean closeOnFocusLost = false;
 
     private color headerColor = OPENBCI_BLUE;
     private color buttonColor = OPENBCI_BLUE;
@@ -29,6 +32,17 @@ class PopupMessage extends PApplet implements Runnable {
 
         headerMessage = header;
         message = msg;
+
+        Thread t = new Thread(this);
+        t.start();        
+    }
+
+    public PopupMessage(String header, String msg, Boolean closeOnFocusLost) {
+        super();
+
+        headerMessage = header;
+        message = msg;
+        this.closeOnFocusLost = closeOnFocusLost;
 
         Thread t = new Thread(this);
         t.start();        
@@ -65,6 +79,20 @@ class PopupMessage extends PApplet implements Runnable {
         Frame frame = ( (PSurfaceAWT.SmoothCanvas) ((PSurfaceAWT)surface).getNative()).getFrame();
         frame.toFront();
         frame.requestFocus();
+
+        if (this.closeOnFocusLost) {
+            // Add a focus listener to the sketch window
+            frame.addFocusListener(new FocusListener() {
+                @Override
+                public void focusGained(FocusEvent e) {}
+
+                @Override
+                public void focusLost(FocusEvent e) {
+                    // Simulate a button pressed to re-use the logic that is in place to properly close the popup
+                    onButtonPressed();
+                }
+            });
+        }
 
         cp5 = new ControlP5(this);
 

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -35,6 +35,7 @@ class TopNav {
 
     public Button layoutButton;
     public Button settingsButton;
+    public Button notesButton;
 
     public LayoutSelector layoutSelector;
     public TutorialSelector tutorialSelector;
@@ -93,6 +94,7 @@ class TopNav {
 
             //Appears at Top Right SubNav while in a Session
             createLayoutButton("Layout", width - 3 - 60, SUBNAV_BUT_Y, 60, SUBNAV_BUT_H, h4, 14, SUBNAV_LIGHTBLUE, WHITE);
+            createNotesButton("Notes", (int)layoutButton.getPosition()[0] - SUBNAV_BUT_W - PAD_3, SUBNAV_BUT_Y, SUBNAV_BUT_W, SUBNAV_BUT_H, h4, 14, SUBNAV_LIGHTBLUE, WHITE);
             secondaryNavInit = true;
         }
 
@@ -173,6 +175,7 @@ class TopNav {
             toggleDataStreamingButton.setVisible(isSession);
             filtersButton.setVisible(isSession);
             layoutButton.setVisible(isSession);
+            notesButton.setVisible(isSession);
            
         }
         if (smoothingButton != null) {
@@ -209,6 +212,7 @@ class TopNav {
 
             layoutButton.setPosition(width - 3 - layoutButton.getWidth(), SUBNAV_BUT_Y);
             settingsButton.setPosition(width - (settingsButton.getWidth()*2) + PAD_3, SUBNAV_BUT_Y);
+            notesButton.setPosition(settingsButton.getPosition()[0] - notesButton.getWidth() - PAD_3, SUBNAV_BUT_Y);
             //Make sure to re-position UI in selector boxes
             layoutSelector.screenResized();
         }
@@ -414,6 +418,34 @@ class TopNav {
             }
         });
         issuesButton.setDescription("If you have suggestions or want to share a bug you've found, please create an issue on the GUI's Github repo!");
+    }
+
+    private void createNotesButton(String text, int _x, int _y, int _w, int _h, PFont font, int _fontSize, color _bg, color _textColor) {
+        final String helpText = "Add notes for the session.";
+        notesButton = createTNButton("notesButton", text, _x, _y, _w, _h, font, _fontSize, _bg, _textColor);
+        notesButton.onRelease(new CallbackListener() {
+            public void controlEvent(CallbackEvent theEvent) {
+                String sessionFolder = settings.getSessionPath();
+                Path filePath = Paths.get(sessionFolder, "notes.txt");
+
+                try {
+                    File file = new File(filePath.toString());
+                    file.createNewFile();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                ProcessBuilder processBuilder = new ProcessBuilder("open", "-e", filePath.toString());
+                processBuilder.directory(new File(sessionFolder.toString()));
+                try {
+                    Process process = processBuilder.start();
+                    int exitCode = process.waitFor();
+                } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        notesButton.setDescription(helpText);
     }
 
     private void createShopButton(String text, int _x, int _y, int _w, int _h, PFont font, int _fontSize, color _bg, color _textColor) {

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -427,7 +427,8 @@ class TopNav {
             public void controlEvent(CallbackEvent theEvent) {
                 String sessionFolder = settings.getSessionPath();
                 if (sessionFolder.isEmpty()) {
-                    new PopupMessage("Session not started.", "Please start a session before attempting to take notes.");
+                    final Boolean closeOnFocusLost = true;
+                    new PopupMessage("Session not started.", "Please start a session before attempting to take notes.", closeOnFocusLost);
                     return;
                 }
 

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -426,6 +426,11 @@ class TopNav {
         notesButton.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
                 String sessionFolder = settings.getSessionPath();
+                if (sessionFolder.isEmpty()) {
+                    new PopupMessage("Session not started.", "Please start a session before attempting to take notes.");
+                    return;
+                }
+
                 Path filePath = Paths.get(sessionFolder, "notes.txt");
 
                 try {

--- a/release/mac/dmgbuild_settings.py
+++ b/release/mac/dmgbuild_settings.py
@@ -207,7 +207,7 @@ license = {
         # RTF (in which case it must start "{\rtf1"), or a path to a file
         # containing the license text.  If you're using RTF,
         # watch out for Python escaping (or read it from a file).
-        "en_US": b"""
+        "en_US": """
             The OpenBCI GUI is licensed under the MIT License.
 
             Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -246,12 +246,12 @@ license = {
         # You don't need to specify them for those languages; if you fail to
         # specify them for some other language, English will be used instead.
         "en_US": (
-            b"English",
-            b"Agree",
-            b"Disagree",
-            b"Print",
-            b"Save",
-            b'Do you agree to the terms of the MIT license? Press "Agree" or "Disagree".',
+            "English",
+            "Agree",
+            "Disagree",
+            "Print",
+            "Save",
+            'Do you agree to the terms of the MIT license? Press "Agree" or "Disagree".',
         ),
     },
 }

--- a/release/sonosReleaseReadme.md
+++ b/release/sonosReleaseReadme.md
@@ -1,0 +1,8 @@
+To release:
+
+- Install the Processing IDE
+- Launch the IDE and then got to `Tools` -> `Install "processing-java"`.
+- Pick whatever option (global or user only install) but the key is to have the `processing-java` script in your PATH.
+- Install the python module `dmgbuild`.
+- Make sure the Processing IDE is closed and run, from the root of the repo : `python3 release/build.py`
+- Then, to create the DMG file : `dmgbuild -s release/mac/dmgbuild_settings.py -D app=$(pwd)/application.macosx/OpenBCI_GUI.app "SonosOpenBCI" SonosOpenBCI_Install.dmg`


### PR DESCRIPTION
Integrates taking notes in the OpenBCI interface. A session must have been started for this to work, the reason being the session folder name is generated when a session recording is triggered and I can't access it before. 

You can simulate a session by selecting `SYNTHETIC` as data source and then just start the session. I believe that just reads made up data from a file.

The `notes.txt` file will be saved in the session folder, in `/Users/<username>/Documents/OpenBCI_GUI/Recordings/<session_id>`